### PR TITLE
Remove deprecated round function in favor of filter

### DIFF
--- a/src/templates/widgets/CartAbandonment/body.twig
+++ b/src/templates/widgets/CartAbandonment/body.twig
@@ -76,7 +76,7 @@
                     stacked: false,
                     ticks: {
                        min: 0,
-                       stepSize: {{ dataCountTotal < 5 ? 1 : round(dataCountTotal) / 5 }}
+                       stepSize: {{ dataCountTotal < 5 ? 1 : (dataCountTotal|round) / 5 }}
                     }
                   }]
                 },


### PR DESCRIPTION
Currently getting deprecation errors on the cart abandonment widget body template — P&T recommend using the filter instead of the function